### PR TITLE
check for existence of window before layout render

### DIFF
--- a/src/components/layoutWrapper.js
+++ b/src/components/layoutWrapper.js
@@ -3,6 +3,10 @@ import PropTypes from "prop-types"
 import Navbar from "../components/navbar"
 
 const LayoutWrapper = ({ children }) => {
+  if (typeof window === `undefined`) {
+    return (<></>);
+  }
+
   return (
     <>
       {children}


### PR DESCRIPTION
looks like this is a gatsby bug potentially

https://stackoverflow.com/a/59534680/10902435

yep... and that fixed it. this is a production-only issue with gatsby in which server-side rendering is causing window-based rendering to get missed on the first render. I think server-side rendering is to help make the site appear faster, but it instead makes the site look broken (as its rendering the mobile version of the site based on the fact that there is no window present on the server)

bummer