### PR TITLE
remove size from image query

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -12,13 +12,7 @@ import profileContent from '../lib/profileContent'
 const AboutPage = ({ isMobile }) => {
   const data = useStaticQuery(graphql`
     query {
-      profile: file(relativePath: { eq: "itme.jpg" }) {
-        childImageSharp {
-          fluid(maxWidth: 500, quality: 100) {
-            ...GatsbyImageSharpFluid
-          }
-        }
-      }
+      profile: file(relativePath: { eq: "itme.jpg" }) { childImageSharp { fluid { ...GatsbyImageSharpFluid } } }
     }
   `)
 


### PR DESCRIPTION
per https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-sizes--resolutions-for-image-queries

size specifiers for image queries have been removed