### PR TITLE
fix issue with navbar following screen resize

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -10,7 +10,6 @@ import withSizes from 'react-sizes'
 import { timeout } from '../lib/timeout'
 import NavbarBorder from './navbarBorder';
 
-
 const Navbar = ({ isMobile }) => {
   const windowAndDocumentIsDefined = () => {
     return typeof window !== 'undefined' && typeof document !== 'undefined'
@@ -27,7 +26,6 @@ const Navbar = ({ isMobile }) => {
     }
 
     calibrateNavBar()
-    addNavBarTransitionCss()
     window.onresize = calibrateNavBar;
     return;
   }, [])
@@ -40,16 +38,18 @@ const Navbar = ({ isMobile }) => {
     setOffset(activeNode.offsetLeft)
   }
 
-  const addNavBarTransitionCss = async function() {
-    await timeout(50)
+  const setActiveMenuItem = async (el) => {
     let navBarEl = document.getElementById(`navbar__border`)
-    navBarEl.classList.add("navbar__links__bottom_border__transition")
-    return;
-  }
 
-  const setActiveMenuItem = (el) => {
+    navBarEl.classList.add("navbar__links__bottom_border__transition")
     setWidth(el.currentTarget.offsetWidth)
     setOffset(el.currentTarget.offsetLeft)
+
+    const transition = document.querySelector('.navbar__links__bottom_border__transition');
+    transition.addEventListener('transitionend', () => {
+      navBarEl.classList.remove("navbar__links__bottom_border__transition")
+    });
+
   }
 
   return (

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -38,7 +38,7 @@ const Navbar = ({ isMobile }) => {
     setOffset(activeNode.offsetLeft)
   }
 
-  const setActiveMenuItem = async (el) => {
+  const setActiveMenuItem = (el) => {
     let navBarEl = document.getElementById(`navbar__border`)
 
     navBarEl.classList.add("navbar__links__bottom_border__transition")

--- a/src/css/components/navbar.css
+++ b/src/css/components/navbar.css
@@ -22,7 +22,7 @@
 
 .navbar__links__bottom_border__transition { 
   transition: border-bottom 0.3s ease;
-  transition: width 2s ease;
+  transition: width 1s ease;
   transition: left 1s ease;
 }
 


### PR DESCRIPTION
this is resolved by adding the transition class only before applying the property changes to the navbar, and then listening for a transition complete event from said transition class to then remove it from the navbar border